### PR TITLE
fix(converters): whitelist vmess `security` so one junk value cannot burn every output file

### DIFF
--- a/scripts/converters.py
+++ b/scripts/converters.py
@@ -693,6 +693,58 @@ def _alpn_list(raw: Any) -> list:
     return out
 
 
+#: مقادیرِ مجازِ `security` در vmess — **تقاطعِ** آنچه sing-box و mihomo
+#: هر دو می‌پذیرند. هر مقدار خارج از این مجموعه با پیامِ «unsupported
+#: security type» کلِ فایل را رد می‌کند، نه فقط همان نود را.
+#:
+#: ★ حادثهٔ ۲۰۲۶-۰۹-۰۷ — چرا این مجموعه وجود دارد:
+#:   یک نودِ vmess با `"scy": "null"` (رشتهٔ «null»، نه مقدارِ تهی) وارد
+#:   پیکره شد. خطِ پیشین `str(obj.get("scy") or "auto")` بود و `or` تنها
+#:   مقادیرِ *falsy* را می‌گیرد؛ «null» یک رشتهٔ **ناتهی** است، پس بی‌هیچ
+#:   اعتبارسنجی تا `cipher` (clash) و `security` (sing-box) می‌رفت.
+#:   نتیجه: ۱ نود از ۱۰٬۹۶۱ چهار سطل از شش سطل (all/heavy/verified/fast)
+#:   را سرخ کرد، گامِ انتشار skip شد و مخزن در یک قفلِ خودپایدار افتاد
+#:   (دادهٔ بد روی main می‌ماند ⇒ دورِ بعد دوباره همان را می‌خواند).
+#:
+#: مقادیر **با اجرای واقعیِ همان باینری‌های pinشدهٔ CI** استخراج شده‌اند
+#: (sing-box 1.13.14 و mihomo v1.19.29)، نه از روی خواندنِ مستندات:
+#:   • sing-box  می‌پذیرد: auto none zero aes-128-cfb aes-128-gcm
+#:                          chacha20-poly1305 **و** رشتهٔ تهی
+#:   • mihomo    می‌پذیرد: همان شش، **به‌علاوهٔ** AUTO/Auto (چون
+#:                          `strings.ToLower` می‌زند) ولی **نه** رشتهٔ تهی
+#:   ⇒ تقاطع = همین شش مقدار. رشتهٔ تهی و گونه‌های بزرگ‌نویس عمداً بیرون
+#:     مانده‌اند چون در یکی از دو کلاینت شکست می‌دهند.
+#: هر دو کلاینت از `metacubex/sing-vmess` استفاده می‌کنند و سوئیچِ
+#: `NewClient` در هر دو فورک کلمه‌به‌کلمه یکسان است — به همین دلیل پیامِ
+#: خطایشان هم یکی بود.
+VMESS_SECURITY: frozenset = frozenset({
+    "auto", "none", "zero", "aes-128-cfb", "aes-128-gcm", "chacha20-poly1305",
+})
+
+
+def _sanitize_vmess_security(scy: Any) -> str:
+    """`scy`ِ vmess → مقداری که **هر دو** کلاینت می‌پذیرند.
+
+    سیاست: **coerce به `auto`**، نه drop. چرا؟ سنجشِ زنده روی همان اجرای
+    شکست‌خورده: تنها ۱ نود از ۱۳۳۱ نودِ vmess مقدارِ نامعتبر داشت و همان نود
+    از آزمونِ پروکسیِ زندهٔ L3 عبور کرده و تا سطلِ `verified/` رسیده بود —
+    یعنی سرور واقعاً کار می‌کند و فقط برچسبِ رمزش زباله است. `auto` همان
+    مذاکرهٔ استانداردِ vmess است (خودِ sing-box هم مقدارِ تهی را به `auto`
+    بدل می‌کند)، پس coerce صفر نود را قربانی می‌کند در حالی که drop یک
+    نودِ **سالم** را دور می‌ریخت.
+
+    `.strip()` لازم است: هر دو کلاینت `"zero "`ِ فاصله‌دار را رد می‌کنند.
+    `.lower()` هم لازم است: sing-box `AUTO` را رد می‌کند (کوچک‌سازی نمی‌کند)
+    هرچند mihomo آن را می‌پذیرد.
+
+    ⚠️ هم‌گامی: `core.dedup_key` نیز باید **همین** نگاشت را بزند، وگرنه دو
+    ورودی که خروجیِ یکسان تولید می‌کنند کلیدِ متفاوت می‌گیرند و ناوردایِ
+    «کلید و خروجی هم‌داستان‌اند» (فاز K) می‌شکند.
+    """
+    s = str(scy or "").strip().lower()
+    return s if s in VMESS_SECURITY else "auto"
+
+
 def parse_proxy(line: str) -> Optional[Dict[str, Any]]:
     """یک URI کانفیگ → dict واسط استاندارد یا None."""
     line = line.strip()
@@ -731,7 +783,7 @@ def parse_proxy(line: str) -> Optional[Dict[str, Any]]:
                 "port": _safe_int(obj.get("port")),
                 "uuid": str(obj.get("id") or ""),
                 "alterId": _safe_int(obj.get("aid"), 0),
-                "cipher": str(obj.get("scy") or "auto"),
+                "cipher": _sanitize_vmess_security(obj.get("scy")),
                 "network": (str(obj.get("net") or "tcp") or "tcp").lower(),
                 "tls": str(obj.get("tls") or "").lower() in ("tls", "reality"),
                 # پیش از این این سه مسیر (vmess/vless/trojan) خام عبور می‌کردند و

--- a/scripts/core.py
+++ b/scripts/core.py
@@ -896,6 +896,21 @@ def _norm_identity_value(key: str, val: str) -> str:
     return v
 
 
+#: آینهٔ `converters.VMESS_SECURITY`. عمداً اینجا **تکرار** شده و import
+#: نمی‌شود: `core` لایهٔ زیرین است و `converters` را import نمی‌کند (وارونگیِ
+#: وابستگی و importِ حلقوی). یک تستِ اختصاصی این دو را قفل می‌کند تا هرگز
+#: واگرا نشوند.
+_VMESS_SECURITY: frozenset = frozenset({
+    "auto", "none", "zero", "aes-128-cfb", "aes-128-gcm", "chacha20-poly1305",
+})
+
+
+def _vmess_security(scy: object) -> str:
+    """همان نگاشتِ `converters._sanitize_vmess_security` — چرایی آنجاست."""
+    s = str(scy or "").strip().lower()
+    return s if s in _VMESS_SECURITY else "auto"
+
+
 def dedup_key(line: str) -> str:
     """Fingerprint هویتِ سرور — CDN-aware (دقیقاً معادل ربات)."""
     line = line.strip()
@@ -992,14 +1007,19 @@ def dedup_key(line: str) -> str:
                 # قاعدهٔ «در تردید، ادغام نکن» می‌شکافیم.
                 f":{net}:{path}:{tls}"
                 f":{_norm_aid(obj.get('aid'))}"
-                # ★ فاز K / K-A: `scy` رمزنگاریِ VMess است و امیت می‌شود:
-                # `converters.py:551` آن را می‌خواند، `:852` به `cipher`
-                # (clash) و `:1143` به `security` (sing-box) می‌نویسد —
-                # **حرف‌به‌حرف و بی‌کوچک‌سازی**. پس کلید هم عیناً همان را
-                # می‌گیرد؛ کوچک‌کردنش «AUTO» و «auto» را ادغام می‌کرد در
-                # حالی که خروجی‌شان متفاوت است. سنجیده شد: ۱ کانفیگ نجات،
-                # ۰ افرازِ کاذب.
-                f":{str(obj.get('scy') or 'auto')}"
+                # ★ فاز K / K-A — **بازنگری‌شده در حادثهٔ ۲۰۲۶-۰۹-۰۷**:
+                # `scy` رمزنگاریِ VMess است و امیت می‌شود (`cipher` در clash،
+                # `security` در sing-box). متنِ پیشین می‌گفت مقدار
+                # «حرف‌به‌حرف و بی‌کوچک‌سازی» امیت می‌شود و کلید هم باید
+                # عیناً همان را بگیرد — و آن **در زمانِ خود درست بود**.
+                # اکنون مبدّل مقدار را از یک whitelist عبور می‌دهد
+                # (`_sanitize_vmess_security`)، چون یک مقدارِ نامعتبر کلِ
+                # فایل را در هر دو کلاینت می‌سوزاند. پس کلید هم باید **همان
+                # نگاشت** را بزند، وگرنه «AUTO» و «auto» — که حالا خروجیِ
+                # یکسان می‌دهند — کلیدِ متفاوت می‌گیرند و ناوردایِ
+                # «کلید و خروجی هم‌داستان‌اند» می‌شکند. سنجیده شد: ۲۲۵ جفت،
+                # ۰ ناسازگاری.
+                f":{_vmess_security(obj.get('scy'))}"
                 # ★ فاز K / K-D — چرایی در بالا، کنارِ محاسبهٔ `srv`.
                 f":srv={srv}"
             )

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -7229,8 +7229,79 @@ def test_zz_k_vmess_scy_absent_equals_auto():
 
 
 def test_zz_k_vmess_scy_case_preserved_like_the_product():
-    """مبدّل مقدار را **حرف‌به‌حرف** امیت می‌کند؛ کوچک‌سازی ادغامِ کاذب بود."""
-    _k_pair(_k_vm(scy="AUTO"), _k_vm(scy="auto"), False, "scy=AUTO در برابر auto")
+    """★ بازنویسی‌شده در حادثهٔ ۲۰۲۶-۰۹-۰۷.
+
+    فرضِ پیشینِ این تست «مبدّل مقدار را حرف‌به‌حرف امیت می‌کند» بود و
+    `scy=AUTO` را جدا از `auto` می‌شمرد. آن فرض دیگر درست نیست: مبدّل حالا
+    `scy` را از whitelistِ `VMESS_SECURITY` عبور می‌دهد، چون یک مقدارِ
+    نامعتبر (نمونهٔ واقعی: رشتهٔ «null») کلِ فایل را در **هر دو** کلاینت
+    می‌سوزاند و چهار سطل را سرخ می‌کند.
+
+    ناوردایِ حقیقی — که هم پیش و هم پس از وصله برقرار است — این است که
+    کلید و خروجی **هم‌داستان** بمانند. پس اکنون `AUTO` و `auto` خروجیِ
+    یکسان می‌دهند، و کلید هم باید یکی شود.
+    """
+    _k_pair(_k_vm(scy="AUTO"), _k_vm(scy="auto"), True, "scy=AUTO در برابر auto")
+    _k_pair(_k_vm(scy="Auto"), _k_vm(scy="auto"), True, "scy=Auto در برابر auto")
+    # مقدارِ زباله هم به `auto` می‌رسد — همان نودی که مخزن را قفل کرد.
+    _k_pair(_k_vm(scy="null"), _k_vm(scy="auto"), True, "scy=null در برابر auto")
+    # ولی مقادیرِ **معتبر و متفاوت** هنوز باید بشکافند.
+    _k_pair(_k_vm(scy="none"), _k_vm(scy="auto"), False, "scy=none در برابر auto")
+
+
+def test_zz_k_vmess_security_whitelist_matches_both_clients() -> None:
+    """`VMESS_SECURITY` دقیقاً تقاطعِ چیزی است که دو کلاینت می‌پذیرند.
+
+    مقادیر با اجرای واقعیِ باینری‌های pinشدهٔ CI استخراج شده‌اند. این تست
+    مجموعه را **قفل** می‌کند تا کسی بعداً مقداری اضافه/کم نکند بی‌آنکه
+    دوباره با کلاینتِ واقعی بسنجد.
+    """
+    assert converters.VMESS_SECURITY == frozenset({
+        "auto", "none", "zero", "aes-128-cfb", "aes-128-gcm",
+        "chacha20-poly1305",
+    }), sorted(converters.VMESS_SECURITY)
+    # رشتهٔ تهی عمداً بیرون است: sing-box می‌پذیرد ولی mihomo رد می‌کند.
+    assert "" not in converters.VMESS_SECURITY
+    # گونه‌های بزرگ‌نویس عمداً بیرون‌اند: mihomo می‌پذیرد ولی sing-box نه.
+    assert "AUTO" not in converters.VMESS_SECURITY
+
+
+def test_zz_k_vmess_security_sanitizer_is_total_and_safe() -> None:
+    """هیچ ورودی‌ای — هرچقدر زباله — نمی‌تواند مقدارِ نامعتبر بیرون بدهد."""
+    JUNK = ["null", "NULL", "None", "undefined", "", "   ", None, 0, [], {},
+            "aes-256-gcm", "chacha20-ietf-poly1305", "rc4-md5", "http", "tls",
+            "AUTO", "Auto", " auto ", "ZERO", "AES-128-GCM", "\n", "\t auto"]
+    for j in JUNK:
+        got = converters._sanitize_vmess_security(j)
+        assert got in converters.VMESS_SECURITY, (j, got)
+    # مقادیرِ معتبر باید **دست‌نخورده** بمانند (با نرمال‌سازیِ حروف/فاصله).
+    for ok in sorted(converters.VMESS_SECURITY):
+        assert converters._sanitize_vmess_security(ok) == ok
+        assert converters._sanitize_vmess_security(ok.upper()) == ok
+        assert converters._sanitize_vmess_security(f"  {ok}  ") == ok
+
+
+def test_zz_k_vmess_security_mirror_never_diverges() -> None:
+    """`core._VMESS_SECURITY` باید آینهٔ دقیقِ `converters.VMESS_SECURITY` باشد.
+
+    `core` نمی‌تواند `converters` را import کند (وارونگیِ وابستگی)، پس
+    مجموعه تکرار شده است. این تست تنها چیزی است که مانعِ واگراییِ خاموشِ
+    آن دو می‌شود — واگرایی یعنی کلید و خروجی از هم می‌پاشند.
+    """
+    assert core._VMESS_SECURITY == converters.VMESS_SECURITY, (
+        sorted(core._VMESS_SECURITY), sorted(converters.VMESS_SECURITY))
+    # ★ این فهرست با mutation testing ساخته شد، نه با حدس. جهشی که فقط
+    # `.lower()` را از آینهٔ `core` برمی‌داشت **زنده ماند**، چون فهرستِ اولیه
+    # تنها مقادیرِ زبالهٔ بزرگ‌نویس (`AUTO`) را می‌آزمود — و آن‌ها در هر دو
+    # پیاده‌سازی به `auto` می‌رسند، پس واگرایی را پنهان می‌کردند. تنها جایی
+    # که نبودِ `.lower()` خود را نشان می‌دهد، مقادیرِ **معتبرِ** بزرگ‌نویس‌اند
+    # (`ZERO`, `NONE`, `AES-128-GCM`) که باید به همان مقدارِ معتبر برسند.
+    probes: list = ["null", "AUTO", "", "zero", " auto ", "aes-256-gcm", None,
+                    "undefined", "  ", 0, [], {}]
+    probes += [v.upper() for v in sorted(converters.VMESS_SECURITY)]
+    probes += [f" {v.title()} " for v in sorted(converters.VMESS_SECURITY)]
+    for j in probes:
+        assert core._vmess_security(j) == converters._sanitize_vmess_security(j), j
 
 
 # ── K-B: `insecure` در hysteria2/tuic ───────────────────────────────────────
@@ -7339,7 +7410,11 @@ def test_zz_k_key_and_product_never_disagree():
     """جمعِ همهٔ سناریوهای فاز K در یک جدول — کلید و خروجی هم‌داستان‌اند."""
     cases = [
         (_k_vm(), _k_vm(scy="auto"), True),
-        (_k_vm(scy="AUTO"), _k_vm(scy="auto"), False),
+        # ★ ۲۰۲۶-۰۹-۰۷: پس از whitelist شدنِ `scy`، این دو خروجیِ یکسان
+        # می‌دهند، پس باید یک کلید بگیرند.
+        (_k_vm(scy="AUTO"), _k_vm(scy="auto"), True),
+        (_k_vm(scy="null"), _k_vm(scy="auto"), True),
+        (_k_vm(scy="none"), _k_vm(scy="auto"), False),
         (_k_vm(net="tcp", sni="f.example.com"), _k_vm(net="tcp"), False),
         (_k_vm(net="grpc", sni="f.example.com"), _k_vm(net="grpc"), False),
         (_k_vm(host="h.example.com", sni="h.example.com"),


### PR DESCRIPTION
## Summary

One vmess node carrying `"scy": "null"` — the **string** «null», not an empty
value — took the whole pipeline down. 4 of 6 buckets went red, step 21
(publish) was skipped, and `main` froze into the familiar self-sustaining
deadlock: bad data stays on `main`, the next round reads it, red again.

This is **not** the same defect as #15. Step 12 (🧪 Unit tests) is still green;
the failing step is **18 — 🔍 Validate outputs with real clients**.

## Root cause

`scripts/converters.py` built the cipher with:

```python
"cipher": str(obj.get("scy") or "auto")
```

`or` only catches *falsy* values. `"null"` is a non-empty string, so it flowed
unvalidated into `security` (sing-box) and `cipher` (clash). Both clients then
reject the **entire document**:

```
FATAL[0000] initialize outbound[9929]: vmess: unsupported security type: null
level=error msg="proxy 10297: vmess: unsupported security type: null"
```

**Exactly 1 node out of 10,961 held 10,960 healthy nodes hostage** — the same
class of incident already documented in the `SSR_CIPHERS` comment ("28 ssr
nodes were holding 22,191 healthy nodes hostage").

| bucket | sing-box | clash |
|---|---|---|
| all | ❌ | ❌ |
| heavy | ❌ | ❌ |
| light | ✅ | ✅ |
| verified | ❌ | ❌ |
| fast | ❌ | ❌ |
| secure | ✅ | ✅ |

## Why this field, and only this field

Every comparable enum in this repo is already whitelisted — `SS_CIPHERS` +
`_sanitize_ss`, `SSR_CIPHERS` + `_sanitize_ssr`, `VLESS_FLOWS` +
`_sanitize_flow`, `_ALPN_ALLOWED`, and the explicit `network` whitelist inside
`_singbox_transport`. **vmess `scy` was the single unguarded exception.** This
PR closes it, following the existing pattern rather than inventing a new one.

## The allowed set was measured, not assumed

Both clients use `metacubex/sing-vmess` — which is why their error text is
identical. The `NewClient` switch was read in both forks, and then **verified
by executing the pinned CI binaries themselves** (sing-box 1.13.14 sha
`68aeab83…`, mihomo v1.19.29 sha `9c397be7…`, both checksum-verified against
the workflow):

| value | sing-box | mihomo | in whitelist |
|---|---|---|---|
| `auto` `none` `zero` `aes-128-cfb` `aes-128-gcm` `chacha20-poly1305` | ✅ | ✅ | **yes** |
| `""` (empty) | ✅ | ❌ | no — fails on mihomo |
| `AUTO` / `Auto` | ❌ | ✅ | no — fails on sing-box |
| `"zero "` (trailing space) | ❌ | ❌ | ⇒ `.strip()` required |
| `null` `undefined` `aes-256-gcm` `chacha20-ietf-poly1305` … | ❌ | ❌ | no |

Probing **corrected my own source reading twice**, which is exactly why the
values are measured rather than transcribed.

## Coerce, not drop

Only 1 of 1,331 vmess nodes was affected — and that node had passed the live
L3 proxy test and reached the `verified/` bucket, so the server genuinely
works; only its cipher *label* is junk. `auto` is standard vmess negotiation
(sing-box itself maps the empty string to `auto`). Coercion loses **zero**
nodes; dropping would have discarded a healthy one.

## `core.dedup_key` moves in lockstep

`core.py` carried the same `str(obj.get('scy') or 'auto')` expression, and the
phase-K contract requires the dedup key to agree with what the product emits.
Patching only the converter would have **split that contract**: `AUTO` and
`auto` now emit identical output, so they must produce identical keys.

Verified across a **225-pair matrix: 0 disagreements**. `core` cannot import
`converters` (layering), so the set is mirrored and a dedicated test locks the
two together forever.

Two existing tests had their *premise* invalidated by this and were rewritten
with an explanation, not deleted.

## Verification

| check | result |
|---|---|
| Full unit suite | **446/446 passed** (443 + 3 new), deterministic 3/3 |
| AST containment | exactly the intended defs changed in all 3 files |
| Mutation testing | **10/10 mutants caught** |
| E2E, real binaries, 26,909 live lines | `sing-box check` **PASS**, `mihomo -t` **PASS** |
| `scripts/validate.py` (the failing step 18) | **pass=12 fail=0, exit 0** |
| Negative control (unpatched, same data) | still fails, identical message |
| `py_compile` / `ast.parse` / `ruff` | clean |

### Mutation testing found a real gap

The first pass caught only **9/10**. A mutant that removed `.lower()` from the
`core` mirror **survived**, because the probe list used only upper-case *junk*
values — which collapse to `auto` in both implementations and therefore hid
the divergence. The test now also probes upper-case **valid** values (`ZERO`,
`NONE`, `AES-128-GCM`), which is the only place the missing `.lower()` shows
itself. Re-run: **10/10 caught**.

### End-to-end reproduction

Built from 26,909 real published lines, with the **actual production culprit**
re-injected plus 20 junk-cipher stress nodes, using the product's own
`build_singbox_json` / `build_clash_yaml`:

```
vmess security distribution AFTER patch:
  {'auto': 2933, 'none': 32, 'aes-128-gcm': 28, 'chacha20-poly1305': 8, 'zero': 2}
securities OUTSIDE the whitelist: 0
sing-box 1.13.14 check : PASS
mihomo v1.19.29 -t     : PASS
```

And `validate.py` — the exact script step 18 runs — over all six buckets:

```
→ pass=12 fail=0 skipped=0 missing=0     (the failing CI run scored pass=4 fail=8)
```

## Note on an earlier false alarm

My first E2E harness reported `invalid REALITY short ID`. I did **not** treat
that as a product defect: measurement showed the real CI artifact contains
**zero** unquoted digit-only short-ids, because the repo already ships
`_YAML12_AMBIGUOUS` + `_clash_dumper` for exactly that hazard. The error was an
artifact of my harness calling raw `yaml.safe_dump`. The harness was rewritten
to call the product's own builders, and it passes. No change was made for it.

## Merge note

The `main` ruleset enforces `required_linear_history`, so this must be merged
with **squash** or **rebase**, not a merge commit. The commit subject carries
no `[auto-output]` marker, so it will become the new publish anchor and the fix
will be carried into every future published tree.
