### PR TITLE
fix(ci): retry transient transport errors — `--retry` alone never fired on a TCP reset

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -467,7 +467,8 @@ jobs:
                     "${{ steps.geoip_key.outputs.ym_prev }}"; do
             URL="https://download.db-ip.com/free/dbip-country-lite-${YM}.mmdb.gz"
             echo "→ trying $URL"
-            if ! curl -fsSL --retry 3 --retry-delay 2 --max-time 120 \
+            if ! curl -fsSL --retry 4 --retry-delay 2 --retry-all-errors \
+                 --retry-max-time 45 --connect-timeout 15 --max-time 120 \
                  -o /tmp/dbip.mmdb.gz "$URL"; then
               echo "  ✗ not available"
               continue
@@ -630,7 +631,8 @@ jobs:
           }
 
           # ── sing-box ────────────────────────────────────────────────────
-          curl -fsSL --retry 3 --retry-delay 2 \
+          curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+            --retry-max-time 60 --connect-timeout 15 --max-time 180 \
             "https://github.com/SagerNet/sing-box/releases/download/v${SING_BOX_VERSION}/sing-box-${SING_BOX_VERSION}-linux-amd64.tar.gz" \
             -o /tmp/sb.tar.gz
           verify /tmp/sb.tar.gz "$SING_BOX_TGZ_SHA256" "sing-box archive"
@@ -640,7 +642,8 @@ jobs:
           install -m 755 "/tmp/sing-box-${SING_BOX_VERSION}-linux-amd64/sing-box" "$HOME/.local/bin/sing-box"
 
           # ── mihomo (فایل .gz تک‌فایلی است، نه tar) ──────────────────────
-          curl -fsSL --retry 3 --retry-delay 2 \
+          curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+            --retry-max-time 60 --connect-timeout 15 --max-time 180 \
             "https://github.com/MetaCubeX/mihomo/releases/download/${MIHOMO_VERSION}/mihomo-linux-amd64-${MIHOMO_VERSION}.gz" \
             -o /tmp/mihomo.gz
           verify /tmp/mihomo.gz "$MIHOMO_GZ_SHA256" "mihomo archive"
@@ -708,7 +711,9 @@ jobs:
           if [ ! -f "$BIN" ]; then
             URL="https://github.com/lilendian0x00/xray-knife/releases/download/v${XRAY_KNIFE_VERSION}/${XRAY_KNIFE_ASSET}"
             echo "→ downloading $URL"
-            curl -fsSL --retry 3 --retry-delay 2 --max-time 300 -o /tmp/xk.zip "$URL"
+            curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+                 --retry-max-time 60 --connect-timeout 15 --max-time 300 \
+                 -o /tmp/xk.zip "$URL"
 
             # تأییدِ آرشیو *پیش از* باز کردن. ترتیب مهم است: باز کردنِ یک
             # آرشیوِ تأییدنشده یعنی اجرای کدِ فشرده‌سازیِ آن روی محتوایی که


### PR DESCRIPTION
## Summary

Run [#11421](https://github.com/0xRadikal/Free-v2ray-Configs/actions/runs/34685887425) died in 52 seconds at **step 14 — 🧰 Install sing-box & mihomo** with:

```
curl: (35) Recv failure: Connection reset by peer
##[error]Process completed with exit code 35
```

That step **already had** `--retry 3 --retry-delay 2`. **The retry never fired.** This PR makes it actually fire — without weakening a single integrity check.

This is **not** related to #15 or #17. Step 12 (unit tests) and step 13 (aggregator) were both green; the run died before step 18 ever executed.

## Why the existing retry was a no-op

From the curl 7.81 manual — the same version the runners ship:

> **Transient error** means either: a **timeout**, an FTP 4xx response code or an HTTP **408, 429, 500, 502, 503, 504, 522 or 524** response code.

A TCP reset is none of those. `--retry` ignored it **by design**.

**The timing proves it rather than arguing it:** the whole step lasted **0.196s** and curl gave up **186 ms** in. With `--retry 3 --retry-delay 2`, one retry alone would have taken ≥ 2 s. So the flag had been sitting in that step, structurally unable to help, for every reset that ever hit it.

## How often does this actually happen?

Measured across the **last 400 aggregate runs** (~2 days):

| | |
|---|---|
| total failures | **1** |
| failures at step 14 | **1** (this one) |
| current failure streak | **0** |

So this is a rare transport flake, not a broken pipeline — the repo self-recovered on the next 5-minute cron. But when it hits, it costs a publish cycle and sends a failure notification, and the retry that was *supposed* to absorb it never ran. That is the real defect being fixed.

## The fix

`--retry-all-errors` (the remedy curl itself documents), plus a hard `--retry-max-time` ceiling and a `--connect-timeout`, on **all four** network downloads:

| download | retry | max-time | notes |
|---|---|---|---|
| GeoIP database | 4 | 45 s | already had a month-fallback loop |
| **sing-box** | 5 | 60 s | ← the step that failed |
| **mihomo** | 5 | 60 s | |
| xray-knife | 5 | 60 s | |

**Budgets were sized from measurement, not taste:**

* step 14 takes **~1.7 s** when healthy (measured over recent successful runs)
* a whole run averages **190 s**, max 363 s
* the cron fires every **300 s**

A 60 s ceiling is ~35× headroom for the download while still finishing inside one cron period. `--connect-timeout 15` stops a black-holed connect from sitting on the default kernel timeout.

## What deliberately did NOT change

This is the part that matters most, so it was verified rather than asserted:

* **Every sha256 `verify` gate is byte-identical**, as are all pinned versions and checksums. Retrying must never become a way to accept a bad artifact. *Measured:* a tampered body makes curl exit 0, and the checksum gate still rejects it.
* **The `-o file` form is kept everywhere.** The manual warns `--retry-all-errors` can duplicate data with `| pipe` or `> file`; with `-o`, curl truncates the partial file before retrying. Both forms were measured on a 1,048,576-byte payload:
  * `-o file` → **1,048,576 bytes, sha256 exact** ✅
  * `> file` → **1,212,416 bytes, sha256 wrong** ❌

  So the `-o` form is load-bearing, not incidental.
* **A permanent failure still fails.** This hardens the retry path; it does not silence the error.

## Verification

| check | result |
|---|---|
| Root cause reproduced offline | byte-identical message |
| Failure matrix (6 scenarios × old/new) | **11/11** |
| Artifact-integrity proof | **7/7** |
| Workflow structure | **24/24** |
| End-to-end with the REAL step-14 script | **15/15** |
| Unit suite / ruff | 446/446 · clean |

### End-to-end — the decisive test

The **actual step-14 `run:` body** was extracted from the patched YAML and executed with its real `env` block and real checksum gates, against a server that resets connections:

| scenario | ORIGINAL script | PATCHED script |
|---|---|---|
| healthy | ✅ 2.11 s | ✅ **2.14 s** (no added delay) |
| **2 resets then OK** | ❌ **exit 56, 1 attempt** | ✅ **exit 0, 4 attempts** |
| permanent reset | — | ❌ exit 56, bounded at 10.1 s |

In the recovery case both installed binaries are **byte-exact**: `68aeab83…` and `9c397be7…`, matching the pinned sha256 values.

The reproduction message matches CI byte-for-byte:

```
curl: (56) Recv failure: Connection reset by peer     <- local harness
curl: (35) Recv failure: Connection reset by peer     <- CI run #11421
```

(56 vs 35 is only HTTP vs HTTPS.)

### Failure matrix

| scenario | CURRENT flags | NEW flags | why it matters |
|---|---|---|---|
| healthy server | ✅ 0.0 s | ✅ 0.0 s | no latency cost |
| reset ×2 then OK | ❌ exit 56 | ✅ exit 0 | **the fix** |
| reset forever | ❌ exit 56 | ❌ exit 56 | no silent pass |
| HTTP 404 (wrong pin) | ❌ exit 22 | ❌ exit 22 | a wrong version is not masked |
| HTTP 500 ×2 then OK | ✅ | ✅ | already transient |
| tampered body | curl 0 / sha ✗ | curl 0 / sha ✗ | checksum gate holds |

### Workflow structure

Still valid YAML · same **21 steps**, same names, same order · only **three** `run` bodies differ · all **15** shell bodies pass `bash -n` · pinned versions and checksums unchanged · diff is exactly **−4/+9** and touches only download lines.

`actionlint` is not available in this environment, so PyYAML structural comparison plus `bash -n` on every shell body were used instead.

## Merge note

The `main` ruleset enforces `required_linear_history`, so this needs **squash** or **rebase**, not a merge commit. The commit subject carries no `[auto-output]` marker, so it becomes the new publish anchor and the fix is carried into every future published tree.
